### PR TITLE
Do not override lncfg defined value for StrictZombiePruning

### DIFF
--- a/server.go
+++ b/server.go
@@ -903,8 +903,6 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 
 	s.controlTower = routing.NewControlTower(paymentControl)
 
-	strictPruning := (cfg.Bitcoin.Node == "neutrino" ||
-		cfg.Routing.StrictZombiePruning)
 	s.chanRouter, err = routing.New(routing.Config{
 		Graph:               chanGraph,
 		Chain:               cc.ChainIO,
@@ -922,7 +920,7 @@ func newServer(cfg *Config, listenAddrs []net.Addr,
 		NextPaymentID:       sequencer.NextID,
 		PathFindingConfig:   pathFindingConfig,
 		Clock:               clock.NewDefaultClock(),
-		StrictZombiePruning: strictPruning,
+		StrictZombiePruning: cfg.Routing.StrictZombiePruning,
 		IsAlias:             aliasmgr.IsAlias,
 	})
 	if err != nil {


### PR DESCRIPTION
## Change Description
In the current implementation of strict zombie pruning, the value of chanRouter is evaluated against `cfg.Bitcoin.Node == neutrino`. If neutrino is used, strict zombie pruning is always on. The original rationale for this appears to be to conserve resources on the server side. This change undoes this aspect and transparently passes the value from lncfg directly to chanRouter, allowing neutrino LND nodes to use non-strict pruning.

## Steps to Test
Tested on a mobile wallet that uses lnd via gomobile, Blixt wallet. I built an Android.aar artifact, but running LND normally should work to repro this. A neutrino node will have strict pruning on regardless of the value in lnd.conf.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#CodeDocumentation) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#IdealGitCommitStructure).
- [x] Any new logging statements use an appropriate subsystem and logging level.
- [x]  [There is a change description in the release notes](https://github.com/lightningnetwork/lnd/tree/master/docs/release-notes), or `[skip ci]` in the commit message for small changes.

📝 Please see our  [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.